### PR TITLE
RA-83 - Create /etc/hosts entries dynamically

### DIFF
--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -162,7 +162,8 @@ module VagrantPlugins
 
                     @vagrant_env.active_machines.each do |name,provider|
 
-                        etc_hosts = "127.0.0.1\tlocalhost localhost.localdomain\n"
+                        etc_hosts = "### Host entries set for Vagrant Cucumber\n"
+                        etc_hosts += "127.0.0.1\tlocalhost localhost.localdomain\n"
                         hosts_array.each do |host|
                             etc_hosts += "#{host[:ip].to_s}\t#{host[:name]}\n"
                         end


### PR DESCRIPTION
- Borrows heavily from Beaker, which implements this to assist with parallel test execution in vagrant via the methods in [host_prebuilt_steps](https://github.com/puppetlabs/beaker/blob/master/lib/beaker/host_prebuilt_steps.rb#L321-L329)
- Requires that [DHCP Private Netwoking](http://docs.vagrantup.com/v2/networking/private_network.html) is set in the Vagrantfile
