### PR TITLE
Strip ANSI escape codes from HTML.

### DIFF
--- a/lib/vagrant-cucumber/cucumber/formatter/html.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/html.rb
@@ -1,5 +1,11 @@
 require 'cucumber/formatter/html'
 
+ANSI_PATTERN = /\e\[(\d+)?(;\d+)?m/
+
+def remove_ansi(string=nil)
+    string.gsub(ANSI_PATTERN, '')
+end
+
 module VagrantPlugins
 
     module Cucumber
@@ -10,10 +16,10 @@ module VagrantPlugins
 
                 def puts(message)
                     # TODO Strip ansi escape codes
-                    @delayed_messages << message
+                    @delayed_messages << remove_ansi(message)
                 end
 
-            end 
+            end
 
         end
 


### PR DESCRIPTION
This strips the ANSI escape codes from messages that are going to be
formatted as HTML. The ANSI_PATTERN should cover the various types of
ANSI opener as well as ANSI close tags.