### PR TITLE
Show @norollback messages only when in debug mode.

### DIFF
--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -70,22 +70,22 @@ Then /^the (.+) of that shell command should(| not) match (\/.+\/)$/ do |stream,
 end
 
 Before('@norollback') do |scenario|
+  if @vagrant_cucumber_debug
     puts "Saw @norollback tag:"
     puts "  * Won't roll back snapshot at end of scenario"
     puts "  * Will roll back explicit snapshots in the scenario"
+  end
 end
 
 
 
 After('~@norollback') do |scenario|
-
     puts "Rolling back VM states"
     vagrant_glue.vagrant_env.cli('snap', 'rollback' )
-
 end
 
 After('@norollback') do |scenario|
-    puts "Saw @norollback tag - not rolling back"
+    puts "Saw @norollback tag - not rolling back" if @vagrant_cucumber_debug
 end
 
 Before('@vagrant-cucumber-debug') do |scenario|


### PR DESCRIPTION
Hello. This patch makes the informational messages about `@norollback` tags only print when debug is turn on.

This is helpful when running Cucumber in less verbose modes, like `--format progress`. Without this patch the output of my test suite looks like this with `--format progress` turned on:

```
Saw @norollback tag:

  * Won't roll back snapshot at end of scenario

  * Will roll back explicit snapshots in the scenario
..
Saw @norollback tag - not rolling back
--
Saw @norollback tag:

  * Won't roll back snapshot at end of scenario

  * Will roll back explicit snapshots in the scenario
.
[... etc]
```