### PR TITLE
Remove multiprovide snap and tidy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## 0.1.0 (Jul 18, 2016)
+
+ * Removed `vagrant-multiprovider-snap` dependency. Vagrant now has all
+   required features.
+ * Updates to various syntax in the code.
+   * "New" style Ruby hashes (no hash rockets).
+   * Removal of some deprecated methods (`Hash#has_key?`, etc)
+ * Quick sweep with `rubocop` to fix some minor style issues.
+ * Fixes to `README.md`, mostly removal of references to
+   `vagrant-multiprovider-snap` with some markdown cleanups.
+
 ## 0.0.10 (May 6, 2015)
 
  * Fixed gemspec to constrain cucumber version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.0 (Jul 18, 2016)
+## WIP
 
  * Removed `vagrant-multiprovider-snap` dependency. Vagrant now has all
    required features.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
 Contributing to vagrant-cucumber
 ================================
 
-We welcome contributions to vagrant-cucumber, either to fix bugs or to add new features.
+We welcome contributions to vagrant-cucumber, either to fix bugs or to add new
+features.
 
 Patch workflow
 --------------
@@ -15,18 +16,23 @@ Patch workflow
 Working with the code
 ---------------------
 
-We use Bundler to manage the development environment with the latest version of Vagrant and its dependencies.  Assuming you have Bundler installed, running ```bundle install``` in the project root will set the environment up for you.
+We use Bundler to manage the development environment with the latest version of
+Vagrant and its dependencies.  Assuming you have Bundler installed, running
+`bundle install` in the project root will set the environment up for you.
 
 
 Testing
 -------
 
-vagrant-cucumber is a reasonably thin glue layer, so doesn't need a whole lot of testing in its current incarnation.  As long as the published example features work, you can be confident your changes haven't broken anything.  To test this, run:
+`vagrant-cucumber` is a reasonably thin glue layer, so doesn't need a whole lot
+of testing in its current incarnation.  As long as the published example
+features work, you can be confident your changes haven't broken anything.  To
+test this, run:
 
 ```
 cd example
 bundle exec vagrant cucumber
 ```
 
-If you add any new behaviour to vagrant-cucumber, please add a feature file to
-the ```example/``` folder which demonstrates how to use it.
+If you add any new behaviour to `vagrant-cucumber`, please add a feature file
+to the `example/` folder which demonstrates how to use it.

--- a/Gemfile
+++ b/Gemfile
@@ -30,22 +30,32 @@ group :development do
         # Jump through annoying hoops so we can use this plugin in the
         # bundler environment.
 
-        fusion_path = Gem::Specification.find_by_name('vagrant-vmware-fusion').gem_dir
+        fusion_gem  = Gem::Specification.find_by_name('vagrant-vmware-fusion')
+        fusion_path = fusion_gem.gem_dir
+        fusion_license_path = File.join(
+            fusion_path,
+            'license-vagrant-vmware-fusion.lic',
+        )
+        fusion_license_vagrantd_path = File.join(
+            ENV['HOME'],
+            '.vagrant.d',
+            'license-vagrant-vmware-fusion.lic',
+        )
 
-        unless File.symlink?(File.join(fusion_path, 'rgloader'))
+        rgloader_local_path    = File.join(fusion_path, 'rgloader')
+        rgloader_embedded_path = File.join(
+            ENV['VAGRANT_INSTALLER_EMBEDDED_DIR'],
+            'rgloader',
+        )
+
+        unless File.symlink?(rgloader_local_path)
             $stderr.puts "Linking local 'rgloader' file to embedded installer"
-            FileUtils.ln_s(
-                File.join(ENV['VAGRANT_INSTALLER_EMBEDDED_DIR'], 'rgloader'),
-                File.join(fusion_path, 'rgloader')
-            )
+            FileUtils.ln_s(rgloader_embedded_path, rgloader_local_path)
         end
 
-        unless File.symlink?(File.join(fusion_path, 'license-vagrant-vmware-fusion.lic'))
-            $stderr.puts "Linking your license file for vmware plugin"
-            FileUtils.ln_s(
-                File.join(ENV['HOME'], '.vagrant.d', 'license-vagrant-vmware-fusion.lic'),
-                File.join(fusion_path, 'license-vagrant-vmware-fusion.lic')
-            )
+        unless File.symlink?(fusion_license_path)
+            $stderr.puts 'Linking your license file for vmware plugin'
+            FileUtils.ln_s(fusion_license_vagrantd_path, fusion_license_path)
         end
     end
 end

--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,18 @@
-source "http://rubygems.org"
-source "http://gems.hashicorp.com"
+source 'http://rubygems.org'
+source 'http://gems.hashicorp.com'
 
 require 'fileutils'
 
-embedded_locations = %w{/Applications/Vagrant/embedded /opt/vagrant/embedded}
+embedded_locations = %w(/Applications/Vagrant/embedded /opt/vagrant/embedded)
 
 embedded_locations.each do |p|
-    ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"] = p if File.directory?(p)
+    ENV['VAGRANT_INSTALLER_EMBEDDED_DIR'] = p if File.directory?(p)
 end
 
-unless ENV.has_key?('VAGRANT_INSTALLER_EMBEDDED_DIR')
+unless ENV.key?('VAGRANT_INSTALLER_EMBEDDED_DIR')
     $stderr.puts "Couldn't find a packaged install of vagrant, and we need this"
-    $stderr.puts "in order to make use of the RubyEncoder libraries."
-    $stderr.puts "I looked in:"
+    $stderr.puts 'in order to make use of the RubyEncoder libraries.'
+    $stderr.puts 'I looked in:'
     embedded_locations.each do |p|
         $stderr.puts "  #{p}"
     end
@@ -23,37 +23,36 @@ group :development do
     # gem dependency because we expect to be installed within the
     # Vagrant environment itself using `vagrant plugin`.
 
-    gem "vagrant", :git => "git://github.com/mitchellh/vagrant.git"
-    gem "rake"
+    gem 'vagrant', git: 'git://github.com/mitchellh/vagrant.git'
+    gem 'rake'
 
     if ENV['VAGRANT_DEFAULT_PROVIDER'] == 'vmware_fusion'
-
         # Jump through annoying hoops so we can use this plugin in the
         # bundler environment.
 
         fusion_path = Gem::Specification.find_by_name('vagrant-vmware-fusion').gem_dir
 
-        unless File.symlink?( File.join( fusion_path, 'rgloader' ) )
+        unless File.symlink?(File.join(fusion_path, 'rgloader'))
             $stderr.puts "Linking local 'rgloader' file to embedded installer"
             FileUtils.ln_s(
-                File.join( ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"], 'rgloader' ), 
-                File.join( fusion_path, 'rgloader' )
+                File.join(ENV['VAGRANT_INSTALLER_EMBEDDED_DIR'], 'rgloader'),
+                File.join(fusion_path, 'rgloader')
             )
         end
 
-        unless File.symlink?( File.join( fusion_path, 'license-vagrant-vmware-fusion.lic' ) )
+        unless File.symlink?(File.join(fusion_path, 'license-vagrant-vmware-fusion.lic'))
             $stderr.puts "Linking your license file for vmware plugin"
             FileUtils.ln_s(
-                File.join( ENV["HOME"], '.vagrant.d', 'license-vagrant-vmware-fusion.lic' ),
-                File.join( fusion_path, 'license-vagrant-vmware-fusion.lic' )
+                File.join(ENV['HOME'], '.vagrant.d', 'license-vagrant-vmware-fusion.lic'),
+                File.join(fusion_path, 'license-vagrant-vmware-fusion.lic')
             )
         end
     end
 end
 
 group :plugins do
-    gem "vagrant-vmware-fusion"
-    gem "vagrant-cucumber", path: "."
-    gem "to_regexp"
-    gem "cucumber"
+    gem 'vagrant-vmware-fusion'
+    gem 'vagrant-cucumber', path: '.'
+    gem 'to_regexp'
+    gem 'cucumber'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,6 @@ unless ENV.has_key?('VAGRANT_INSTALLER_EMBEDDED_DIR')
 end
 
 group :development do
-
     # We depend on Vagrant for development, but we don't add it as a
     # gem dependency because we expect to be installed within the
     # Vagrant environment itself using `vagrant plugin`.
@@ -36,9 +35,9 @@ group :development do
 
         unless File.symlink?( File.join( fusion_path, 'rgloader' ) )
             $stderr.puts "Linking local 'rgloader' file to embedded installer"
-            FileUtils.ln_s( 
+            FileUtils.ln_s(
                 File.join( ENV["VAGRANT_INSTALLER_EMBEDDED_DIR"], 'rgloader' ), 
-                File.join( fusion_path, 'rgloader' ) 
+                File.join( fusion_path, 'rgloader' )
             )
         end
 
@@ -49,16 +48,12 @@ group :development do
                 File.join( fusion_path, 'license-vagrant-vmware-fusion.lic' )
             )
         end
-
     end
-
 end
 
 group :plugins do
     gem "vagrant-vmware-fusion"
     gem "vagrant-cucumber", path: "."
-    gem "vagrant-multiprovider-snap"
     gem "to_regexp"
     gem "cucumber"
 end
-

--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2013 The Scale Factory Ltd
+Copyright (c) 2010-2016 The Scale Factory Ltd
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -4,8 +4,8 @@ Vagrant Cucumber
 Description
 -----------
 
-This plugin allows Vagrant to run cucumber features, and provides some glue
-for working with vagrant boxes within your cucumber steps.
+This plugin allows Vagrant to run Cucumber features, and provides some glue
+for working with Vagrant boxes within your Cucumber steps.
 
 It was originally developed to help us test configuration management scripts,
 and with the following workflow in mind:
@@ -13,7 +13,7 @@ and with the following workflow in mind:
  * Start one or more Vagrant boxes
  * Configure these boxes with some default state
  * Snapshot each box in this default state.
- * In each cucumber scenario
+ * In each Cucumber scenario
     - Run config management tools inside the box to make configuration changes
     - Test that these changes produce the desired result
     - Roll the VM state back, ready for the next scenario
@@ -22,8 +22,8 @@ and with the following workflow in mind:
 Requirements
 ------------
 
-The plugin requires cucumber and vagrant-multiprovider-snap gems, but will
-install these itself if required.
+The plugin requires the `cucumber` gem, but will install this itself if
+required.
 
 Vagrant Cucumber currently works only with the current Vagrant providers:
 
@@ -31,30 +31,26 @@ Vagrant Cucumber currently works only with the current Vagrant providers:
  * VMWare Fusion (using the commercial VMWare plugin for Vagrant)
 
 
-
 Installation
 ------------
 
-Assuming you're running the packaged version of Vagrant, the easiest way to 
+Assuming you're running the packaged version of Vagrant, the easiest way to
 install this plugin is via the published gem:
 
 ```
 vagrant plugin install vagrant-cucumber
 ```
 
-As well as the vagrant-cucumber plugin, this will also install the
-vagrant-multiprovider-snap plugin if you don't already have it.
-
-vagrant-cucumber will also install a version of cucumber >= 1.3.2 under the
+`vagrant-cucumber` will install a version of cucumber >= 1.3.2 under the
 Ruby environment provided by Vagrant.
 
 
 Usage
 -----
 
-This plugin adds a subcommand, ```vagrant cucumber``` - this simply wraps
-the usual ```cucumber``` commandline handler - refer to the documentation for
-cucumber for details, or use ```vagrant cucumber -h``` for a full list of
+This plugin adds a subcommand, `vagrant cucumber` - this simply wraps
+the usual `cucumber` command line handler. Refer to the documentation for
+cucumber for details, or use `vagrant cucumber -h` for a full list of
 options.
 
 
@@ -67,51 +63,50 @@ a Vagrantfile and features directory which demonstrates the plugin in action.
 The Vagrantfile defines two basic VMs which will be used to run our tests.
 It will work with either the Virtualbox or the VMWare Fusion provider.
 
-Use ```vagrant up``` in that folder in order to start the default VM. (In the
+Use `vagrant up` in that folder in order to start the default VM. (In the
 current version of the plugin, VMs must be running before they can be used
-in tests).  If you don't already have the standard precise64 vagrant box, it 
+in tests).  If you don't already have the standard `precise64` vagrant box, it
 will be fetched from the Vagrant website.  If you prefer to use the VMWare
-provider, add ```--provider=vmware_fusion``` to the commandline.
+provider, add `--provider=vmware_fusion` to the commandline.
 
-To run all the tests, run 
+To run all the tests, run:
 
-```vagrant cucumber```.
+`vagrant cucumber`.
 
-The tests are split between multiple feature files. You can run one feature 
+The tests are split between multiple feature files. You can run one feature
 file at a time by specifying it on the commandline:
 
-```vagrant cucumber features/basic.feature```
+`vagrant cucumber features/basic.feature`
 
-```basic.feature``` demonstrates running basic shell commands inside the VM
-both as the standard vagrant user, and as root.  It also contains a test to show
-that snapshot rollback is working correctly.  
+`basic.feature` demonstrates running basic shell commands inside the VM
+both as the standard `vagrant` user, and as `root`.  It also contains a test to
+show that snapshot rollback is working correctly.
 
-```multivm.feature``` shows how steps can reference different VMs.  For details
+`multivm.feature` shows how steps can reference different VMs.  For details
 on how to write your own step definitions which can work on multiple VMs,
 see the next section.
 
-The test in ```multivm.feature``` also demonstrates use of cucumber tags.
-The test scenario is preceded with the tag ```@vagrant-cucumber-debug```. This
+The test in `multivm.feature` also demonstrates use of cucumber tags.
+The test scenario is preceded with the tag `@vagrant-cucumber-debug`. This
 causes debug output to be emitted.
 
-We also provide a ```@norollback``` tag, which prevents the VMs from being
+We also provide a `@norollback` tag, which prevents the VMs from being
 rolled back at the end of the scenario.  This is useful for debugging.
-
 
 
 Implementation Detail
 ---------------------
 
 The best place to gain an understanding of the implementation of Cucumber steps
-is in ```example/features/step_definitions/process.rb```.  I've heavily
+is in `example/features/step_definitions/process.rb`.  I've heavily
 commented this in order to be a good working example.
 
-```example/features/process.feature``` uses these step definitions.
+`example/features/process.feature` uses these step definitions.
 
-Other step definitions and hooks are defined in ```lib/vagrant-cucumber/step_definitions.rb```.
-
+Other step definitions and hooks are defined in
+`lib/vagrant-cucumber/step_definitions.rb`.
 
 
 License
 -------
-vagrant-cucumber is licensed under the MIT license.
+`vagrant-cucumber` is licensed under the MIT license.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ and with the following workflow in mind:
 Requirements
 ------------
 
+Since `0.1.x` this plugin requires a minimum Vagrant version of `1.8.4`.
+
 The plugin requires the `cucumber` gem, but will install this itself if
 required.
 

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,9 +1,10 @@
 Vagrant.configure("2") do |config|
 
-    config.vm.box     = "precise64"
-    config.vm.box_url = "http://files.vagrantup.com/precise64.box"
+    config.vm.box     = "ubuntu/precise64"
 
-    config.vm.provider :vmware_fusion do |fusion,override|
+    config.vm.provider :virtualbox
+
+    config.vm.provider :vmware_fusion do |fusion, override|
         override.vm.box     = "precise64_vmware_fusion"
         override.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
     end

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,12 +1,11 @@
-Vagrant.configure("2") do |config|
-
-    config.vm.box     = "ubuntu/precise64"
+Vagrant.configure('2') do |config|
+    config.vm.box = "ubuntu/precise64"
 
     config.vm.provider :virtualbox
 
     config.vm.provider :vmware_fusion do |fusion, override|
-        override.vm.box     = "precise64_vmware_fusion"
-        override.vm.box_url = "http://files.vagrantup.com/precise64_vmware_fusion.box"
+        # Standard Ubuntu image doesn't exist for VMWare
+        override.vm.box = "hashicorp/precise64"
     end
 
     config.vm.define :vm1 do |vm1|

--- a/lib/vagrant-cucumber.rb
+++ b/lib/vagrant-cucumber.rb
@@ -1,9 +1,9 @@
-require "vagrant-cucumber/version"
-require "vagrant-cucumber/plugin"
-require "vagrant-cucumber/glue"
+require 'vagrant-cucumber/version'
+require 'vagrant-cucumber/plugin'
+require 'vagrant-cucumber/glue'
 
 module VagrantPlugins
-  module Cucumber
-    # ... 
-  end
+    module Cucumber
+        # ...
+    end
 end

--- a/lib/vagrant-cucumber/commands/cucumber.rb
+++ b/lib/vagrant-cucumber/commands/cucumber.rb
@@ -6,17 +6,15 @@ FORCE_COLOUR_ENV_VARS = [
 module VagrantPlugins
     module Cucumber
         class CucumberCommand < Vagrant.plugin(2, :command)
-
-            FORCE_COLOUR_ENV_VARS.each { |k|
-                if ENV.has_key?(k)
+            FORCE_COLOUR_ENV_VARS.each do |k|
+                if ENV.key?(k)
                     require 'cucumber/term/ansicolor'
                     ::Cucumber::Term::ANSIColor.coloring = true
                     break
                 end
-            }
+            end
 
             def execute
-
                 require 'cucumber/rspec/disable_option_parser'
                 require 'cucumber/cli/main'
 
@@ -27,10 +25,7 @@ module VagrantPlugins
                 VagrantPlugins::Cucumber::Glue::VagrantGlue.set_environment(@env)
 
                 failure = ::Cucumber::Cli::Main.execute(@argv)
-
             end
-
         end
     end
 end
-

--- a/lib/vagrant-cucumber/cucumber/formatter/html.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/html.rb
@@ -2,29 +2,19 @@ require 'cucumber/formatter/html'
 
 ANSI_PATTERN = /\e\[(\d+)?(;\d+)?m/
 
-def remove_ansi(string=nil)
+def remove_ansi(string = nil)
     string.gsub(ANSI_PATTERN, '')
 end
 
 module VagrantPlugins
-
     module Cucumber
-
         module Formatter
-
             class Html < ::Cucumber::Formatter::Html
-
                 def puts(message)
-                    # TODO Strip ansi escape codes
+                    # TODO: Strip ansi escape codes
                     @delayed_messages << remove_ansi(message)
                 end
-
             end
-
         end
-
     end
-
 end
-
-

--- a/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
@@ -1,13 +1,9 @@
 require 'cucumber/formatter/pretty'
 
 module VagrantPlugins
-
     module Cucumber
-
         module Formatter
-
             class Pretty < ::Cucumber::Formatter::Pretty
-
                 # Use the Pretty formatter, but disable use of
                 #  delayed messages (ie. output each line at once)
 
@@ -24,13 +20,7 @@ module VagrantPlugins
 
                 def print_table_row_messages
                 end
-
             end
-
         end
-
     end
-
 end
-
-

--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -43,7 +43,7 @@ module VagrantPlugins
                     machine_name     = nil
 
                     # If this machine name is not configured, blow up
-                    if ! @vagrant_env.machine_names.index(vmname.to_sym)
+                    unless @vagrant_env.machine_names.index(vmname.to_sym)
                         raise Vagrant::Errors::VMNotFoundError, :name => vmname
                     end
 
@@ -54,7 +54,7 @@ module VagrantPlugins
                         end
                     end
 
-                    if !machine_name
+                    unless machine_name
                         raise "The VM '#{vmname}' is configured in the Vagrantfile "+
                             "but has not been started.  Run 'vagrant up #{vmname}' and "+
                             "specify a provider if necessary."

--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -44,7 +44,7 @@ module VagrantPlugins
 
                     # If this machine name is not configured, blow up
                     unless @vagrant_env.machine_names.index(vmname.to_sym)
-                        raise Vagrant::Errors::VMNotFoundError, :name => vmname
+                        raise Vagrant::Errors::VMNotFoundError, name: vmname
                     end
 
                     @vagrant_env.active_machines.each do |a_name, a_provider|
@@ -61,8 +61,10 @@ module VagrantPlugins
                     end
 
                     machine_provider ||= vagrant_env.default_provider
+
                     machine = @vagrant_env.machine(
-                        machine_name, machine_provider
+                        machine_name,
+                        machine_provider
                     )
 
                     @last_machine_mentioned = vmname
@@ -75,7 +77,7 @@ module VagrantPlugins
                         when /^( on the last VM|)$/
                             get_last_vm
                         when /^ on the VM(?: called|) "([^"]+)"$/
-                            get_vm( $1 )
+                            get_vm($1)
                     end
                 end
 
@@ -84,8 +86,8 @@ module VagrantPlugins
 
                 def execute_on_vm(command, machine, opts = {})
                     @last_shell_command_output = {
-                        :stdout => '',
-                        :stderr => '',
+                        stdout: '',
+                        stderr: '',
                     }
 
                     @last_shell_command_status = nil
@@ -93,10 +95,10 @@ module VagrantPlugins
                     machine.communicate.tap do |comm|
                         @last_shell_command_status = comm.execute(
                             command, {
-                                :error_check => false,
-                                :sudo        => opts[:as_root]
+                                error_check: false,
+                                sudo:        opts[:as_root]
                             }
-                        ) do |type,data|
+                        ) do |type, data|
                             if @vagrant_cucumber_debug
                                 puts "[:#{type}] #{data.chomp}"
                             end
@@ -109,7 +111,7 @@ module VagrantPlugins
                         if @last_shell_command_status != 0
                             raise "Expected command to return non-zero, got #{@last_shell_command_status}"
                         end
-                    elsif opts.has_key?(:expect)
+                    elsif opts.key?(:expect)
                         if @last_shell_command_status != opts[:expect]
                             raise "Expected command to return #{opts[:expect]}, got #{@last_shell_command_status}"
                         end

--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -3,11 +3,8 @@ unless defined?(VMRE)
 end
 
 module VagrantPlugins
-
     module Cucumber
-
         module Glue
-
             # This glue module will be used in the cucumber World for
             #  tests run with vagrant-cucumber.  It's used to hide interaction
             #  with the messier parts of the vagrant environment so the
@@ -18,7 +15,6 @@ module VagrantPlugins
             end
 
             class VagrantGlue
-
                 @@vagrant_env = nil
 
                 def self.set_environment(env)
@@ -26,10 +22,8 @@ module VagrantPlugins
                 end
 
                 def initialize
-
                     @vagrant_env = @@vagrant_env or raise "The vagrant_env hasn't been set"
                     @last_machine_mentioned = nil
-
                 end
 
                 def self.instance
@@ -41,11 +35,10 @@ module VagrantPlugins
                 end
 
                 def get_last_vm
-                    get_vm( @last_machine_mentioned )
+                    get_vm(@last_machine_mentioned)
                 end
 
-                def get_vm( vmname )
-
+                def get_vm(vmname)
                     machine_provider = nil
                     machine_name     = nil
 
@@ -55,34 +48,29 @@ module VagrantPlugins
                     end
 
                     @vagrant_env.active_machines.each do |a_name, a_provider|
-
                         if a_name == vmname.to_sym
                             machine_provider = a_provider
                             machine_name     = a_name
                         end
-
                     end
 
                     if !machine_name
-
                         raise "The VM '#{vmname}' is configured in the Vagrantfile "+
                             "but has not been started.  Run 'vagrant up #{vmname}' and "+
                             "specify a provider if necessary."
-
                     end
 
                     machine_provider ||= vagrant_env.default_provider
-                    machine = @vagrant_env.machine( 
+                    machine = @vagrant_env.machine(
                         machine_name, machine_provider
                     )
 
                     @last_machine_mentioned = vmname
 
                     machine
-
                 end
 
-                def identified_vm( str )
+                def identified_vm(str)
                     case str
                         when /^( on the last VM|)$/
                             get_last_vm
@@ -91,12 +79,10 @@ module VagrantPlugins
                     end
                 end
 
-
                 attr_reader :last_shell_command_status
                 attr_reader :last_shell_command_output
 
-                def execute_on_vm ( command, machine, opts = {} )
-
+                def execute_on_vm(command, machine, opts = {})
                     @last_shell_command_output = {
                         :stdout => '',
                         :stderr => '',
@@ -105,46 +91,31 @@ module VagrantPlugins
                     @last_shell_command_status = nil
 
                     machine.communicate.tap do |comm|
-
                         @last_shell_command_status = comm.execute(
                             command, {
                                 :error_check => false,
                                 :sudo        => opts[:as_root]
                             }
                         ) do |type,data|
-
                             if @vagrant_cucumber_debug
                                 puts "[:#{type}] #{data.chomp}"
                             end
 
                             @last_shell_command_output[type] += data
-
                         end
-
                     end
 
                     if opts[:expect_nonzero]
-
                         if @last_shell_command_status != 0
                             raise "Expected command to return non-zero, got #{@last_shell_command_status}"
                         end
-
                     elsif opts.has_key?(:expect)
-
                         if @last_shell_command_status != opts[:expect]
                             raise "Expected command to return #{opts[:expect]}, got #{@last_shell_command_status}"
                         end
-
                     end
-
                 end
-
             end
-
-
         end
-
     end
-
 end
-

--- a/lib/vagrant-cucumber/plugin.rb
+++ b/lib/vagrant-cucumber/plugin.rb
@@ -1,26 +1,22 @@
 begin
-    require "vagrant"
+    require 'vagrant'
 rescue LoadError
-    raise "The Vagrant Cucumber plugin must be run within Vagrant."
+    raise 'The Vagrant Cucumber plugin must be run within Vagrant.'
 end
 
 module VagrantPlugins
-    module Cucumber 
-        class Plugin < Vagrant.plugin("2")
-
-            require 'vagrant-multiprovider-snap'
-
-            name "Cucumber"
+    module Cucumber
+        class Plugin < Vagrant.plugin('2')
+            name 'Cucumber'
 
             description <<-DESC
             This plugin makes it possible for Cucumber to interact with Vagrant
             DESC
 
-            command "cucumber" do
-                require_relative "commands/cucumber"
+            command 'cucumber' do
+                require_relative 'commands/cucumber'
                 CucumberCommand
             end
-
         end
     end
 end

--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -5,7 +5,7 @@ Given /^there is a running VM called "([^"]*)"$/ do |vmname|
 
     machine.action(:up)
 
-    unless machine.provider.driver.has_snapshot?
+    if machine.provider.capability(:snapshot_list).empty?
         vagrant_glue.vagrant_env.cli('snapshot', 'push', vmname)
     end
 end

--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -11,7 +11,8 @@ Given /^there is a running VM called "([^"]*)"$/ do |vmname|
 end
 
 When /^I roll back the VM called "([^"]*)"$/ do |vmname|
-    machine = vagrant_glue.get_vm( vmname )
+    machine = vagrant_glue.get_vm(vmname)
+
     vagrant_glue.vagrant_env.cli(
         'snapshot',
         'pop',
@@ -21,65 +22,66 @@ When /^I roll back the VM called "([^"]*)"$/ do |vmname|
     )
 end
 
-Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})(?:|, it) should (succeed|fail)$/ do |command,as_root,vmre,condition|
+Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})(?:|, it) should (succeed|fail)$/ do |command, as_root, vmre, condition|
     options = {
-        :as_root          => ( as_root == ' as root' ),
-        :expect_non_zero  => ( condition == 'fail' ),
+        as_root:         (as_root == ' as root'),
+        expect_non_zero: (condition == 'fail'),
     }
 
-    if condition == 'succeed'
-        options[:expect] = 0
-    end
+    options[:expect] = 0 if condition == 'succeed'
 
-    vagrant_glue.execute_on_vm( command, vagrant_glue.identified_vm(vmre), options )
-
+    vagrant_glue.execute_on_vm(
+        command,
+        vagrant_glue.identified_vm(vmre),
+        options
+    )
 end
 
-Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})$/ do |command,as_root,vmre|
-
+Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})$/ do |command, as_root, vmre|
     options = {
-        :machine          => vagrant_glue.identified_vm(vmre),
-        :as_root          => ( as_root == ' as root' ),
+        machine: vagrant_glue.identified_vm(vmre),
+        as_root: (as_root == ' as root'),
     }
 
-    vagrant_glue.execute_on_vm( command, vagrant_glue.identified_vm(vmre), options )
-
+    vagrant_glue.execute_on_vm(
+        command,
+        vagrant_glue.identified_vm(vmre),
+        options
+    )
 end
 
-
-Then /^the (.+) of that shell command should(| not) match (\/.+\/)$/ do |stream,condition,re|
-
+Then /^the (.+) of that shell command should(| not) match (\/.+\/)$/ do |stream, condition, re|
     stream.downcase!
 
-    unless vagrant_glue.last_shell_command_output.has_key?( stream.to_sym )
+    unless vagrant_glue.last_shell_command_output.key?(stream.to_sym)
         raise "vagrant_glue.last_shell_command_output structure has no #{stream}"
     end
 
-    re_result = ( vagrant_glue.last_shell_command_output[stream.to_sym] =~ re.to_regexp )
+    re_result = (
+        vagrant_glue.last_shell_command_output[stream.to_sym] =~ re.to_regexp
+    )
+
     re_matched = !re_result.nil?
 
     should_match = condition != ' not'
 
-    if re_matched and !should_match
+    if re_matched && !should_match
         raise "Regular expression matched, but shouldn't have"
     end
 
-    if !re_matched and should_match
+    if !re_matched && should_match
         raise "Regular expression didn't match, but should have"
     end
-
 end
 
-Before('@norollback') do |scenario|
-    puts "Saw @norollback tag:"
+Before('@norollback') do |_scenario|
+    puts 'Saw @norollback tag:'
     puts "  * Won't roll back snapshot at end of scenario"
-    puts "  * Will roll back explicit snapshots in the scenario"
+    puts '  * Will roll back explicit snapshots in the scenario'
 end
 
-
-
-After('~@norollback') do |scenario|
-    puts "Rolling back VM states"
+After('~@norollback') do |_scenario|
+    puts 'Rolling back VM states'
     vagrant_glue.vagrant_env.cli(
         'snapshot',
         'pop',
@@ -88,11 +90,11 @@ After('~@norollback') do |scenario|
     )
 end
 
-After('@norollback') do |scenario|
-    puts "Saw @norollback tag - not rolling back"
+After('@norollback') do |_scenario|
+    puts 'Saw @norollback tag - not rolling back'
 end
 
-Before('@vagrant-cucumber-debug') do |scenario|
-    puts "Enabling debugging for vagrant-cucumber scenarios"
+Before('@vagrant-cucumber-debug') do |_scenario|
+    puts 'Enabling debugging for vagrant-cucumber scenarios'
     @vagrant_cucumber_debug = true
 end

--- a/lib/vagrant-cucumber/version.rb
+++ b/lib/vagrant-cucumber/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
     module Cucumber
-        VERSION = '0.1.0'
+        VERSION = '0.0.10'
     end
 end

--- a/lib/vagrant-cucumber/version.rb
+++ b/lib/vagrant-cucumber/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
-  module Cucumber
-    VERSION = "0.0.10"
-  end
+    module Cucumber
+        VERSION = '0.1.0'
+    end
 end

--- a/vagrant-cucumber.gemspec
+++ b/vagrant-cucumber.gemspec
@@ -1,33 +1,33 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path("../lib", __FILE__)
-require "vagrant-cucumber/version"
+$:.push File.expand_path('../lib', __FILE__)
+require 'vagrant-cucumber/version'
 
 Gem::Specification.new do |s|
-  s.name        = "vagrant-cucumber"
-  s.version     = VagrantPlugins::Cucumber::VERSION
-  s.authors     = ["Jon Topper"]
-  s.email       = ["jon@scalefactory.com"]
-  s.homepage    = "https://github.com/scalefactory/vagrant-cucumber"
-  s.summary     = %q{Cucumber support for Vagrant}
-  s.description = %q{This plugin makes it possible for Cucumber to interact with Vagrant}
-  s.license     = 'MIT'
+    s.name        = 'vagrant-cucumber'
+    s.version     = VagrantPlugins::Cucumber::VERSION
+    s.authors     = ['Jon Topper']
+    s.email       = ['jon@scalefactory.com']
+    s.homepage    = 'https://github.com/scalefactory/vagrant-cucumber'
+    s.summary     = 'Cucumber support for Vagrant'
+    s.description = 'This plugin makes it possible for Cucumber to interact with Vagrant'
+    s.license     = 'MIT'
 
-  s.rubyforge_project = "vagrant-cucumber"
+    s.rubyforge_project = 'vagrant-cucumber'
 
-  files = `git ls-files`.split("\n")
-  ignore = %w{Gemfile Rakefile .gitignore}
+    files = `git ls-files`.split("\n")
+    ignore = %w(Gemfile Rakefile .gitignore)
 
-  files.delete_if do |f|
-      ignore.any? do |i|
-          File.fnmatch(i, f, File::FNM_PATHNAME) ||
-          File.fnmatch(i, File.basename(f), File::FNM_PATHNAME)
-      end
-  end
+    files.delete_if do |f|
+        ignore.any? do |i|
+            File.fnmatch(i, f, File::FNM_PATHNAME) ||
+                File.fnmatch(i, File.basename(f), File::FNM_PATHNAME)
+        end
+    end
 
-  s.add_runtime_dependency "cucumber", "~>1.3.2"
-  s.add_runtime_dependency "to_regexp", ">=0.2.1"
+    s.add_runtime_dependency 'cucumber', '~>1.3.2'
+    s.add_runtime_dependency 'to_regexp', '>=0.2.1'
 
-  s.files         = files
-  s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
-  s.require_paths = ["lib"]
+    s.files         = files
+    s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }
+    s.require_paths = ['lib']
 end

--- a/vagrant-cucumber.gemspec
+++ b/vagrant-cucumber.gemspec
@@ -23,13 +23,11 @@ Gem::Specification.new do |s|
           File.fnmatch(i, File.basename(f), File::FNM_PATHNAME)
       end
   end
-  
+
   s.add_runtime_dependency "cucumber", "~>1.3.2"
-  s.add_runtime_dependency "vagrant-multiprovider-snap", ">=0.0.4"
   s.add_runtime_dependency "to_regexp", ">=0.2.1"
 
   s.files         = files
   s.executables   = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
   s.require_paths = ["lib"]
-
 end


### PR DESCRIPTION
* Removes the dependency on `vagrant-multiprovider-snap` by using the new core Vagrant functionality.
  - This likely requires a version bump from `0.0.x` to `0.1.x`.
* Tidies up various bits of Ruby all over the place to appease Rubocop.
* Updates the year in the `LICENSE`.
* Fixes the `Vagrantfile` in the examples so that it prefers VirtualBox over VMWare.
  - Running the examples under VMWare is broken anyway, as there is no `ubuntu/precise64` box for VMWare.
* Updates the `README.md` to mention the new minimum version for Vagrant (`1.8.4`).