### PR TITLE
Only perform the :up action if the VM isn't in the :running state.

### DIFF
--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -57,7 +57,9 @@ end
 
 Given /^there is a running VM called "([^"]*)"$/ do |vmname|
     machine = vagrant_glue.get_vm(vmname)
-    machine.action(:up)
+
+    machine.action(:up) unless machine.state.id == :running
+
     push_snapshot(vmname) unless snapshots_enabled?(vmname)
 end
 


### PR DESCRIPTION
Since we require the user to perform a `vagrant up` before running the Cucumber tests, the `action(:up)` here seems to be optional.
This change makes it so that the action is only performed if the VM isn't in the `:running` state.

This should save some time as the `:up` action would have rerun provisioners which shouldn't be needed as we either:
- Have just performed a `vagrant up`.
- Have just rolled back, so we're in the state snapshotted  directly after performing a `vagrant up`.
