### PR TITLE
Add support for vagrant-libvirt

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,0 +1,26 @@
+Style/IndentationWidth:
+    Width: 4
+
+Metrics/LineLength:
+    Enabled: false
+
+Metrics/MethodLength:
+    Enabled: false
+
+Style/Documentation:
+    Enabled: false
+
+Style/AccessorMethodName:
+    Enabled: false
+
+Style/ClassVars:
+    Enabled: false
+
+Metrics/AbcSize:
+    Enabled: false
+
+Lint/AmbiguousRegexpLiteral:
+    Enabled: false
+
+Style/FileName:
+    Enabled: false

--- a/Gemfile
+++ b/Gemfile
@@ -34,18 +34,18 @@ group :development do
         fusion_path = fusion_gem.gem_dir
         fusion_license_path = File.join(
             fusion_path,
-            'license-vagrant-vmware-fusion.lic',
+            'license-vagrant-vmware-fusion.lic'
         )
         fusion_license_vagrantd_path = File.join(
             ENV['HOME'],
             '.vagrant.d',
-            'license-vagrant-vmware-fusion.lic',
+            'license-vagrant-vmware-fusion.lic'
         )
 
         rgloader_local_path    = File.join(fusion_path, 'rgloader')
         rgloader_embedded_path = File.join(
             ENV['VAGRANT_INSTALLER_EMBEDDED_DIR'],
-            'rgloader',
+            'rgloader'
         )
 
         unless File.symlink?(rgloader_local_path)

--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,1 @@
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'

--- a/example/Vagrantfile
+++ b/example/Vagrantfile
@@ -1,11 +1,11 @@
 Vagrant.configure('2') do |config|
-    config.vm.box = "ubuntu/precise64"
+    config.vm.box = 'ubuntu/precise64'
 
     config.vm.provider :virtualbox
 
-    config.vm.provider :vmware_fusion do |fusion, override|
+    config.vm.provider :vmware_fusion do |_fusion, override|
         # Standard Ubuntu image doesn't exist for VMWare
-        override.vm.box = "hashicorp/precise64"
+        override.vm.box = 'hashicorp/precise64'
     end
 
     config.vm.define :vm1 do |vm1|
@@ -15,5 +15,4 @@ Vagrant.configure('2') do |config|
     config.vm.define :vm2 do |vm2|
         vm2.vm.hostname = 'vm2'
     end
-
 end

--- a/example/features/step_definitions/process.rb
+++ b/example/features/step_definitions/process.rb
@@ -1,16 +1,15 @@
-# Cucumber step definitions are defined like function definitions, and start 
+# Cucumber step definitions are defined like function definitions, and start
 # with a preposition or adverb (Given, When, Then, And, But).
-# 
+#
 # The regular expression defined will be matched against steps in the feature
 # files when cucumber runs.  The matched groups in the regex will be passed
-# in order as variables to the block.  In this case, the three groups are 
+# in order as variables to the block.  In this case, the three groups are
 # assigned to "condition", "process_name" and "vmre"
 #
 # More information on step definitions can be found at
 # https://github.com/cucumber/cucumber/wiki/Step-Definitions
 
 Then /there should(| not) be a process called "([^"]*)" running(#{VMRE})$/ do |condition, process_name, vmre|
-
     # First, we work out what virtual machine we're going to be dealing with
     # in this step.  The VMRE variable in the regex above is defined by
     # vagrant-cucumber to match various English-language ways in which we
@@ -28,50 +27,40 @@ Then /there should(| not) be a process called "([^"]*)" running(#{VMRE})$/ do |c
 
     machine = vagrant_glue.identified_vm(vmre)
 
-
     # Now we use the machine's communication interface (probably ssh, though
     # this is provider-dependent) to execute a shell command inside the VM.
 
     machine.communicate.tap do |comm|
+        rv = comm.execute(
+            "pidof #{process_name}",
+            error_check: false, # stop vagrant throwing an exception
+            # if the command returns non-zero
 
-        rv = comm.execute( 
-            "pidof #{process_name}", { 
-                :error_check => false, # stop vagrant throwing an exception
-            }                          # if the command returns non-zero
-            
-        ) do |type,data|
-
+        ) do |type, data|
             # Execute takes a block, which is yielded to whenever there's
             # output on stdout or stderr.  We handle any output in this block.
             #
             # In this case, we'll put all output onto stdout, but only if
             # @vagrant_cucumber_debug has been set.  This class variable will
-            # be set to true in the Before hook defined in 
+            # be set to true in the Before hook defined in
             # lib/vagrant-cucumber/step_definitions.rb
 
-            if @vagrant_cucumber_debug
-                puts "[:#{type}] #{data.chomp}"
-            end
-
+            puts "[:#{type}] #{data.chomp}" if @vagrant_cucumber_debug
         end
 
         # Output the status from the command if we're in debugging mode
-        if @vagrant_cucumber_debug
-            puts "Exit status of pidof command: #{rv}"
-        end
+        puts "Exit status of pidof command: #{rv}" if @vagrant_cucumber_debug
 
         # Cucumber steps are expected to exit cleanly if they worked ok, and
         # raise exceptions if they fail.  The following logic implements
         # the conditions in which we want to fail the step.
 
-        if rv != 0 and condition == ''
+        if rv != 0 && condition == ''
             raise "There was no proces called #{process_name} running on #{machine.name}"
         end
 
-        if rv == 0 and condition == ' not'
+        if rv == 0 && condition == ' not'
             raise "There was a process called #{process_name} running on #{machine.name}"
         end
-
     end
-
 end

--- a/example/features/support/env.rb
+++ b/example/features/support/env.rb
@@ -1,3 +1,3 @@
 require 'vagrant-cucumber/step_definitions'
 
-World( VagrantPlugins::Cucumber::Glue )
+World(VagrantPlugins::Cucumber::Glue)

--- a/lib/vagrant-cucumber/commands/cucumber.rb
+++ b/lib/vagrant-cucumber/commands/cucumber.rb
@@ -1,17 +1,16 @@
-FORCE_COLOUR_ENV_VARS = [
-    'VAGRANT_CUCUMBER_FORCE_COLOR',
-    'VAGRANT_CUCUMBER_FORCE_COLOUR',
-]
+FORCE_COLOUR_ENV_VARS = %w(
+    VAGRANT_CUCUMBER_FORCE_COLOR
+    VAGRANT_CUCUMBER_FORCE_COLOUR
+).freeze
 
 module VagrantPlugins
     module Cucumber
         class CucumberCommand < Vagrant.plugin(2, :command)
             FORCE_COLOUR_ENV_VARS.each do |k|
-                if ENV.key?(k)
-                    require 'cucumber/term/ansicolor'
-                    ::Cucumber::Term::ANSIColor.coloring = true
-                    break
-                end
+                next unless ENV.key?(k)
+                require 'cucumber/term/ansicolor'
+                ::Cucumber::Term::ANSIColor.coloring = true
+                break
             end
 
             def execute
@@ -24,7 +23,7 @@ module VagrantPlugins
 
                 VagrantPlugins::Cucumber::Glue::VagrantGlue.set_environment(@env)
 
-                failure = ::Cucumber::Cli::Main.execute(@argv)
+                _ = ::Cucumber::Cli::Main.execute(@argv)
             end
         end
     end

--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -22,17 +22,15 @@ module VagrantPlugins
                 end
 
                 def initialize
-                    @vagrant_env = @@vagrant_env or raise "The vagrant_env hasn't been set"
+                    (@vagrant_env = @@vagrant_env) || raise("The vagrant_env hasn't been set")
                     @last_machine_mentioned = nil
                 end
 
                 def self.instance
-                    return @@instance ||= VagrantGlue.new
+                    @@instance ||= VagrantGlue.new
                 end
 
-                def vagrant_env
-                    @vagrant_env
-                end
+                attr_reader :vagrant_env
 
                 def get_last_vm
                     get_vm(@last_machine_mentioned)
@@ -55,9 +53,9 @@ module VagrantPlugins
                     end
 
                     unless machine_name
-                        raise "The VM '#{vmname}' is configured in the Vagrantfile "+
-                            "but has not been started.  Run 'vagrant up #{vmname}' and "+
-                            "specify a provider if necessary."
+                        raise "The VM '#{vmname}' is configured in the Vagrantfile "\
+                              "but has not been started.  Run 'vagrant up #{vmname}' and "\
+                              'specify a provider if necessary.'
                     end
 
                     machine_provider ||= vagrant_env.default_provider
@@ -74,10 +72,10 @@ module VagrantPlugins
 
                 def identified_vm(str)
                     case str
-                        when /^( on the last VM|)$/
-                            get_last_vm
-                        when /^ on the VM(?: called|) "([^"]+)"$/
-                            get_vm($1)
+                    when /^( on the last VM|)$/
+                        get_last_vm
+                    when /^ on the VM(?: called|) "([^"]+)"$/
+                        get_vm(Regexp.last_match(1))
                     end
                 end
 
@@ -87,17 +85,15 @@ module VagrantPlugins
                 def execute_on_vm(command, machine, opts = {})
                     @last_shell_command_output = {
                         stdout: '',
-                        stderr: '',
+                        stderr: ''
                     }
 
                     @last_shell_command_status = nil
 
                     machine.communicate.tap do |comm|
                         @last_shell_command_status = comm.execute(
-                            command, {
-                                error_check: false,
-                                sudo:        opts[:as_root]
-                            }
+                            command, error_check: false,
+                                     sudo:        opts[:as_root]
                         ) do |type, data|
                             if @vagrant_cucumber_debug
                                 puts "[:#{type}] #{data.chomp}"

--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -12,7 +12,7 @@ def pop_snapshot(vmname = nil)
         'snapshot',
         'pop',
         '--no-provision',
-        '--no-delete',
+        '--no-delete'
     ]
     args << vmname unless vmname.nil?
 
@@ -31,7 +31,7 @@ Given /^there is a running VM called "([^"]*)"$/ do |vmname|
 end
 
 When /^I roll back the VM called "([^"]*)"$/ do |vmname|
-    machine = vagrant_glue.get_vm(vmname)
+    _machine = vagrant_glue.get_vm(vmname)
 
     pop_snapshot(vmname)
 end
@@ -39,7 +39,7 @@ end
 Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})(?:|, it) should (succeed|fail)$/ do |command, as_root, vmre, condition|
     options = {
         as_root:         (as_root == ' as root'),
-        expect_non_zero: (condition == 'fail'),
+        expect_non_zero: (condition == 'fail')
     }
 
     options[:expect] = 0 if condition == 'succeed'
@@ -54,7 +54,7 @@ end
 Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})$/ do |command, as_root, vmre|
     options = {
         machine: vagrant_glue.identified_vm(vmre),
-        as_root: (as_root == ' as root'),
+        as_root: (as_root == ' as root')
     }
 
     vagrant_glue.execute_on_vm(
@@ -64,7 +64,7 @@ Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})$/ do |comm
     )
 end
 
-Then /^the (.+) of that shell command should(| not) match (\/.+\/)$/ do |stream, condition, re|
+Then %r{/^the (.+) of that shell command should(| not) match (\/.+\/)$/} do |stream, condition, re|
     stream.downcase!
 
     unless vagrant_glue.last_shell_command_output.key?(stream.to_sym)

--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -3,23 +3,32 @@ require 'to_regexp'
 def push_snapshot(vmname)
     case machine_provider(vmname)
     when :libvirt
-        require 'sahara/session/factory'
-        ses = Sahara::Session::Factory.create(vagrant_glue.get_vm(vmname))
-        unless ses.is_snapshot_mode_on?
-            vagrant_glue.vagrant_env.cli('sandbox', 'on', vmname)
-            vagrant_glue.vagrant_env.cli('sandbox', 'commit', vmname)
-        end
+        vagrant_glue.vagrant_env.cli('sandbox', 'on', vmname)
+        vagrant_glue.vagrant_env.cli('sandbox', 'commit', vmname)
     when :no_machines
         return
     else
-        machine = vagrant_glue.get_vm(vmname)
-        vagrant_glue.vagrant_env.cli('snapshot', 'push', vmname) if machine.provider.capability(:snapshot_list).empty?
+        vagrant_glue.vagrant_env.cli('snapshot', 'push', vmname)
     end
 rescue Vagrant::Errors::EnvironmentLockedError
     sleep 0.2
     retry
 rescue LoadError
     raise 'Please install the `sahara` vagrant plugin.'
+end
+
+def snapshots_enabled?(vmname)
+    case machine_provider(vmname)
+    when :libvirt
+        require 'sahara/session/factory'
+        ses = Sahara::Session::Factory.create(vagrant_glue.get_vm(vmname))
+        ses.is_snapshot_mode_on?
+    when :no_machines
+        return false
+    else
+        machine = vagrant_glue.get_vm(vmname)
+        !machine.provider.capability(:snapshot_list).empty?
+    end
 end
 
 def machine_provider(vmname)
@@ -49,7 +58,7 @@ end
 Given /^there is a running VM called "([^"]*)"$/ do |vmname|
     machine = vagrant_glue.get_vm(vmname)
     machine.action(:up)
-    push_snapshot(vmname)
+    push_snapshot(vmname) unless snapshots_enabled?(vmname)
 end
 
 When /^I roll back the VM called "([^"]*)"$/ do |vmname|

--- a/lib/vagrant-cucumber/version.rb
+++ b/lib/vagrant-cucumber/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
     module Cucumber
-        VERSION = '0.1.1'
+        VERSION = '0.1.1'.freeze
     end
 end

--- a/vagrant-cucumber.gemspec
+++ b/vagrant-cucumber.gemspec
@@ -1,5 +1,5 @@
 # -*- encoding: utf-8 -*-
-$:.push File.expand_path('../lib', __FILE__)
+$LOAD_PATH.push File.expand_path('../lib', __FILE__)
 require 'vagrant-cucumber/version'
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
Vagrant-libvirt does not currently support the built in Vagrant snapshot feature, so this PR adds support for libvirt using the [https://github.com/jedi4ever/sahara](Sahara) plugin.
