### PR TITLE
gemspec: Add sahara to runtime dependency

### DIFF
--- a/vagrant-cucumber.gemspec
+++ b/vagrant-cucumber.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
 
     s.add_runtime_dependency 'cucumber', '~>1.3.2'
     s.add_runtime_dependency 'to_regexp', '>=0.2.1'
+    s.add_runtime_dependency 'sahara', '~>0.0.17'
 
     s.files         = files
     s.executables   = `git ls-files -- bin/*`.split("\n").map { |f| File.basename(f) }


### PR DESCRIPTION
For completeness, we should add sahara as a dependency.