### PR TITLE
html formatter: More ANSI regex pattern matching

### DIFF
--- a/lib/vagrant-cucumber/cucumber/formatter/html.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/html.rb
@@ -1,6 +1,6 @@
 require 'cucumber/formatter/html'
 
-ANSI_PATTERN = /\e\[(\d+)?(;\d+)?m/
+ANSI_PATTERN = /\e\[\d+([;\d]+)?m/
 
 def remove_ansi(string = nil)
     string.gsub(ANSI_PATTERN, '')
@@ -11,7 +11,6 @@ module VagrantPlugins
         module Formatter
             class Html < ::Cucumber::Formatter::Html
                 def puts(message)
-                    # TODO: Strip ansi escape codes
                     @delayed_messages << remove_ansi(message)
                 end
             end


### PR DESCRIPTION
Support stripping of multiple, chained ANSI control codes.
In addition, support stripping of TRUECOLOR ANSI codes.

E.g:
`"\e[38;2;255;100;0mTRUECOLOR\e[0m\n\e[31mHello\e[0m\e[34mWorld\e[0m"`