### PR TITLE
Cucumber: Bump to version 2.4+ of Cucumber

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.0 (December, 2016)
+ * Upgrade Cucumber to 2.x release. No longer requires native extensions for Gherkin,
+   thus allowing installation on Vagrant 1.9.1
+ * Support for libvirt using Sahara plugin
+
 ## 0.1.1 (26 July, 2016)
 
  * Retry snapshot operations on lock failure.

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ install this plugin is via the published gem:
 vagrant plugin install vagrant-cucumber
 ```
 
-`vagrant-cucumber` will install a version of cucumber >= 1.3.2 under the
+`vagrant-cucumber` will install a version of cucumber >= 2.4.0 under the
 Ruby environment provided by Vagrant.
 
 

--- a/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
                 # Use the Pretty formatter, but disable use of
                 #  delayed messages (ie. output each line at once)
 
-                def initialize(*args)
+                def initialize(runtime, path_or_io = STDOUT, options = {})
                     super
                     @delayed_messages = nil
                 end

--- a/lib/vagrant-cucumber/version.rb
+++ b/lib/vagrant-cucumber/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
     module Cucumber
-        VERSION = '0.1.1'.freeze
+        VERSION = '1.0.0'.freeze
     end
 end

--- a/vagrant-cucumber.gemspec
+++ b/vagrant-cucumber.gemspec
@@ -24,8 +24,8 @@ Gem::Specification.new do |s|
         end
     end
 
-    s.add_runtime_dependency 'cucumber', '~>1.3.2'
-    s.add_runtime_dependency 'to_regexp', '>=0.2.1'
+    s.add_runtime_dependency 'cucumber', '~>2.4'
+    s.add_runtime_dependency 'to_regexp', '~>0.2.1'
     s.add_runtime_dependency 'sahara', '~>0.0.17'
 
     s.files         = files


### PR DESCRIPTION
Bring Cucumber version up to date.

This makes this plugin installable on Vagrant 1.9.1

Importantly, this also bring Ruby 2.2 support, given that Ruby 2.1 will be EOL at the end of 2016.

Fixes #10 