### PR TITLE
Pretty formatter: Fix broken options handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
-## 1.0.0 (December, 2016)
+## 1.0.1 (13 December, 2016)
+ * FIX: Restore options in pretty formatter.
+
+Note: If you would like immediate standard output from commands, you will need to
+use "Kernel.puts" or "STDOUT.puts" in Cucumber 2+.
+
+## 1.0.0 (12 December, 2016)
  * Upgrade Cucumber to 2.x release. No longer requires native extensions for Gherkin,
    thus allowing installation on Vagrant 1.9.1
  * Support for libvirt using Sahara plugin

--- a/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
+++ b/lib/vagrant-cucumber/cucumber/formatter/pretty.rb
@@ -7,7 +7,7 @@ module VagrantPlugins
                 # Use the Pretty formatter, but disable use of
                 #  delayed messages (ie. output each line at once)
 
-                def initialize(runtime, path_or_io = STDOUT, options = {})
+                def initialize(runtime, path_or_io, options)
                     super
                     @delayed_messages = nil
                 end

--- a/lib/vagrant-cucumber/version.rb
+++ b/lib/vagrant-cucumber/version.rb
@@ -1,5 +1,5 @@
 module VagrantPlugins
     module Cucumber
-        VERSION = '1.0.0'.freeze
+        VERSION = '1.0.1'.freeze
     end
 end


### PR DESCRIPTION
Fix up against version 1.0.0

Stopping delayed messages for "puts" in step definitions becomes a downstream responsibility in Cucumber 2+, as per https://github.com/cucumber/cucumber-ruby/blob/master/lib/cucumber/rb_support/rb_world.rb#L76