### PR TITLE
Fix the regex-inside-a-regex, which never matched as expected.

### DIFF
--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -95,7 +95,7 @@ Then /^(?:running|I run) the shell command `(.*)`(| as root)(#{VMRE})$/ do |comm
     )
 end
 
-Then %r{/^the (.+) of that shell command should(| not) match (\/.+\/)$/} do |stream, condition, re|
+Then /^the (.+) of that shell command should(| not) match (\/.+\/)$/ do |stream, condition, re|
     stream.downcase!
 
     unless vagrant_glue.last_shell_command_output.key?(stream.to_sym)


### PR DESCRIPTION
The double regex was preventing the output matching steps from working. When running the `examples`, I got the following output:

```
6 scenarios (2 undefined, 4 passed)
26 steps (5 undefined, 21 passed)
4m34.166s

You can implement step definitions for undefined steps with these snippets:

Then(/^the stdout of that shell command should match \/vagrant\/$/) do
  pending # Write code here that turns the phrase above into concrete actions
end

Then(/^the stdout of that shell command should not match \/root\/$/) do
  pending # Write code here that turns the phrase above into concrete actions
end

Then(/^the stderr of that shell command should match \/\^\$\/$/) do
  pending # Write code here that turns the phrase above into concrete actions
end

Then(/^the stdout of that shell command should match \/root\/$/) do
  pending # Write code here that turns the phrase above into concrete actions
end

Then(/^the stdout of that shell command should not match \/vagrant\/$/) do
  pending # Write code here that turns the phrase above into concrete actions
end
```

This fixes that, and all of the examples run cleanly with it applied.
