### PR TITLE
fixed vagrant-cucumber-debug flag

### DIFF
--- a/example/features/step_definitions/process.rb
+++ b/example/features/step_definitions/process.rb
@@ -41,15 +41,15 @@ Then /there should(| not) be a process called "([^"]*)" running(#{VMRE})$/ do |c
             # output on stdout or stderr.  We handle any output in this block.
             #
             # In this case, we'll put all output onto stdout, but only if
-            # @vagrant_cucumber_debug has been set.  This class variable will
+            # $vagrant_cucumber_debug has been set.  This class variable will
             # be set to true in the Before hook defined in
             # lib/vagrant-cucumber/step_definitions.rb
 
-            puts "[:#{type}] #{data.chomp}" if @vagrant_cucumber_debug
+            puts "[:#{type}] #{data.chomp}" if $vagrant_cucumber_debug
         end
 
         # Output the status from the command if we're in debugging mode
-        puts "Exit status of pidof command: #{rv}" if @vagrant_cucumber_debug
+        puts "Exit status of pidof command: #{rv}" if $vagrant_cucumber_debug
 
         # Cucumber steps are expected to exit cleanly if they worked ok, and
         # raise exceptions if they fail.  The following logic implements

--- a/lib/vagrant-cucumber/glue.rb
+++ b/lib/vagrant-cucumber/glue.rb
@@ -95,7 +95,7 @@ module VagrantPlugins
                             command, error_check: false,
                                      sudo:        opts[:as_root]
                         ) do |type, data|
-                            if @vagrant_cucumber_debug
+                            if $vagrant_cucumber_debug
                                 puts "[:#{type}] #{data.chomp}"
                             end
 

--- a/lib/vagrant-cucumber/step_definitions.rb
+++ b/lib/vagrant-cucumber/step_definitions.rb
@@ -136,5 +136,10 @@ end
 
 Before('@vagrant-cucumber-debug') do |_scenario|
     puts 'Enabling debugging for vagrant-cucumber scenarios'
-    @vagrant_cucumber_debug = true
+    $vagrant_cucumber_debug = true
+end
+
+After('@vagrant-cucumber-debug') do |_scenario|
+    puts 'Disabling debugging for vagrant-cucumber scenarios'
+    $vagrant_cucumber_debug = false
 end


### PR DESCRIPTION
I found that setting the `@vagrant-cucumber-debug` tag didn't actually cause any debugging information to be printed in my tests.

As a class variable, `@vagrant_cucumber_debug` doesn't seem to stay in scope during the execution of cucumber tests. Modifying `@vagrant_cucumber_debug` to become a ruby global solves the issue.